### PR TITLE
Remove ability to color tab bar icons

### DIFF
--- a/ios/RCCTabBarController.m
+++ b/ios/RCCTabBarController.m
@@ -159,7 +159,7 @@
       iconImage = [RCTConvert UIImage:icon];
       if (buttonColor)
       {
-        iconImage = [[self image:iconImage withColor:buttonColor] imageWithRenderingMode:UIImageRenderingModeAlwaysOriginal];
+        iconImage = [iconImage imageWithRenderingMode:UIImageRenderingModeAlwaysOriginal];
       }
     }
     UIImage *iconImageSelected = nil;


### PR DESCRIPTION
Motivation:
- we are currently rendering colored icons directly from the `png`s

This PR removes the ability to color tab bar icons on iOS.

TODO:
- do the same for **Android**