### PR TITLE
[Lightbox] fix android dismiss lightbox

### DIFF
--- a/android/app/src/main/java/com/reactnativenavigation/views/LightBox.java
+++ b/android/app/src/main/java/com/reactnativenavigation/views/LightBox.java
@@ -107,7 +107,7 @@ public class LightBox extends Dialog implements DialogInterface.OnDismissListene
     }
 
     public void destroy() {
-        content.unmountReactView();
+        // content.unmountReactView();
         dismiss();
     }
 


### PR DESCRIPTION
Follows the advice in this PR https://github.com/wix/react-native-navigation/pull/1734 to "fix" the crash in Android after a Lightbox dismiss. 